### PR TITLE
Fixed setup.py so that submoduled are installed as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from setuptools import setup
-
+from setuptools import setup, find_packages
 
 setup(name='treeoclock',
       version='1.0.0',
@@ -8,7 +7,7 @@ setup(name='treeoclock',
       author='Lars Berling',
       # author_email='flyingcircus@example.com',
       license='MIT',
-      packages=['treeoclock'],
+      packages=find_packages(),
       install_requires=['ete3',
                         'pandas',
                         'seaborn'


### PR DESCRIPTION
With `packages=['treeoclock']`, only the top-most module (`treeoclock`) is installed, but not any of the submodules.

Fixed using the automatic module discovery `find_packages` from `setuptools`

See https://setuptools.pypa.io/en/latest/userguide/package_discovery.html